### PR TITLE
Added "FN012" and "FN124" to import table list

### DIFF
--- a/R/import_fn_creel1.R
+++ b/R/import_fn_creel1.R
@@ -26,8 +26,8 @@ import_fn_creel <- function(generic_datazip) {
     usethis::ui_stop("Input file expects a DATA.ZIP file")
   }
   
-  AllTables <- c("FN011", "FN022", "FN023", "FN024", "FN025", "FN026", "FN028", "FN111", 
-                  "FN112", "FN121", "FN123", "FN125", "FN126", "FN127")
+  AllTables <- c("FN011", "FN012", "FN022", "FN023", "FN024", "FN025", "FN026", "FN028", "FN111", 
+                  "FN112", "FN121", "FN123", "FN124", "FN125", "FN126", "FN127")
   
   # Create and unzip data to a temp file
   mytemp <- tempdir()


### PR DESCRIPTION
New GLIS template now has tables for FN012 and FN124. Not ALL creels will have these tables, but it is nice to have them wrapped in the same import function.